### PR TITLE
fix language names

### DIFF
--- a/i18next-parser.config.js
+++ b/i18next-parser.config.js
@@ -1,5 +1,5 @@
 export default {
   locales: ["en", "ja"],
   output: "src/locales/$LOCALE/$NAMESPACE.json",
-  keepRemoved: ["ttl", "languages"],
+  keepRemoved: ["ttl"],
 };

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -4,7 +4,7 @@ import { atom, useAtom, useAtomValue, useSetAtom } from "jotai";
 import { ArrowUpCircle, Github, Globe, LogOut, Moon, RotateCw, Sun, Zap } from "lucide-react";
 import React, { useEffect, useRef } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { supportedLangCodes } from "../locales/i18n";
+import { langNameTable, supportedLangCodes } from "../locales/i18n";
 import { myAccountDataAtom, useHardReload, useLogout, useWriteOpsEnabled } from "../states/nostr";
 import { AccountMetadata } from "../states/nostrModels";
 import { ColorTheme, colorThemeAtom } from "../states/theme";
@@ -148,7 +148,7 @@ const MenuItemSwitchLangage: React.FC = () => {
           <DropdownMenuRadioGroup value={i18n.language} onValueChange={(v) => onLangChange(v)}>
             {supportedLangCodes.map((lang) => (
               <DropdownMenuRadioItem className={radioItemClassNames} value={lang}>
-                <span>{t(`languages.${lang}`)}</span>
+                <span>{langNameTable[lang]}</span>
               </DropdownMenuRadioItem>
             ))}
           </DropdownMenuRadioGroup>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -5,10 +5,6 @@
   "Light": "Light",
   "Dark": "Dark",
   "Language": "Language",
-  "languages": {
-    "en": "English",
-    "ja": "Japanese"
-  },
   "Zap Author": "Zap Author",
   "View Code on GitHub": "View Code on GitHub",
   "Hard Reload": "Hard Reload",

--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -5,8 +5,12 @@ import { initReactI18next } from "react-i18next";
 import en from "./en/translation.json";
 import ja from "./ja/translation.json";
 
-export const supportedLangCodes = ["en", "ja"];
+export const supportedLangCodes = ["en", "ja"] as const;
 export type LangCode = (typeof supportedLangCodes)[number];
+export const langNameTable: Record<LangCode, string> = {
+  en: "English",
+  ja: "日本語",
+};
 
 const resources = {
   en: {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -5,10 +5,6 @@
   "Light": "ライト",
   "Dark": "ダーク",
   "Language": "言語",
-  "languages": {
-    "en": "English",
-    "ja": "日本語"
-  },
   "Zap Author": "作者に Zap",
   "View Code on GitHub": "GitHub でコードを見る",
   "Hard Reload": "ハードリロード",


### PR DESCRIPTION
use the text "日本語" for "Japanese" even if English is selected.