### PR TITLE
Fix issues related to user relay list detection

### DIFF
--- a/src/nostr.ts
+++ b/src/nostr.ts
@@ -46,25 +46,25 @@ const parseRelayListInKind10002 = (ev: NostrEvent): RelayList | undefined => {
   for (const t of getTagsByName(ev, "r")) {
     const [, url, usage] = t;
     if (url === undefined) {
-      return;
+      continue;
     }
     switch (usage) {
       case undefined:
       case "":
         res[url] = { read: true, write: true };
-        return;
+        break;
 
       case "read":
         res[url] = { read: true, write: false };
-        return;
+        break;
 
       case "write":
         res[url] = { read: false, write: true };
-        return;
+        break;
 
       default:
         console.warn("invalid relay type in kind 10002 event:", usage);
-        return;
+        break;
     }
   }
 

--- a/src/states/nostr.ts
+++ b/src/states/nostr.ts
@@ -258,9 +258,8 @@ const defaultBootstrapRelays = ["wss://relay.nostr.band", "wss://directory.yabu.
 
 const fallbackRelayList: RelayList = {
   "wss://relay.nostr.band": { read: true, write: true },
-  "wss://relayable.org": { read: true, write: true },
-  "wss://relay.damus.io": { read: false, write: true },
-  "wss://yabu.me": { read: true, write: false },
+  "wss://nos.lol": { read: true, write: true },
+  "wss://yabu.me": { read: true, write: true },
 };
 
 // first, get read relays from NIP-07 extension if available. if no relays found, use default relays.


### PR DESCRIPTION
- add/remove relays to/from fallback relays list: 
  - remove wss://relayable.org: no longer available
  - remove wss://relay.damus.io: seems to be unstable, add wss://nos.lol instead
- fix a bug in parsing kind 10002
- use relays in kind 10002 as much as possible